### PR TITLE
Add cli-sound binary

### DIFF
--- a/.changeset/beige-walls-matter.md
+++ b/.changeset/beige-walls-matter.md
@@ -1,0 +1,5 @@
+---
+"cli-sound": minor
+---
+
+Added `cli-sound` binary to execute it from the terminal.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@
 
 A simple utility to play sounds from Node.js programs, useful for (but not limited to) CLI apps.
 
-It works by executing a locally installed program without displaying a graphical interface.
+It can also be used directly as a terminal command:
 
-This package is inspired by [play-sound](https://github.com/shime/play-sound), but it goes to greater lengths to ensure good cross-operative-system support, provide volume control, customization, TypeScript types, ESM and CommonJS compatibility, and overall better reliability.
+```sh
+npm i -g cli-sound
+cli-sound path/to/sound.mp3
+
+# or
+npx cli-sound path/to/sound.mp3
+```
+
+It works by executing a locally installed audio program without a graphical interface.
+
+This package is inspired by [play-sound](https://github.com/shime/play-sound), but it goes to greater lengths to ensure good cross-operative-system support, provide volume control, customization, TypeScript types, ESM and CommonJS compatibility, and better reliability overall.
 
 ## <a name='Install'></a>Install
 
@@ -147,9 +157,10 @@ There are two points at which an error can occur:
 - Creating the player (`new Player()`): happens if none of the programs are available.
 - Playing a sound (`player.play()`): happens if the program command fails for some reason, including but not limited to the file not existing or being in the wrong format.
 
-If playing the sound is not a critical feature, it is recommended to wrap the code in a try/catch block.
+If succeeding in playing the sound is not critical, you can wrap the code in a try/catch block to prevent the failure from crashing your app.
 
-Note that, since the package doesn't have a lot of control over the spawned programs, the program may fail silently or behave in unexpected ways.
+> [!WARNING]
+> Note that, since the package doesn't have a lot of control over the spawned programs, they may fail silently or behave in unexpected ways.
 
 ## <a name='Inspectingthecommand'></a>Inspecting the command
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "prepare": "tshy",
     "publish": "changeset publish",
-    "test": "tsx test/index.ts"
+    "test": "tsx test/index.ts",
+    "cli": "tsx src/cli.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
@@ -31,6 +32,9 @@
     "tshy": "^1.8.0",
     "tsx": "^4.1.0",
     "typescript": "^5.2.2"
+  },
+  "bin": {
+    "cli-sound": "./dist/esm/cli.js"
   },
   "tshy": {
     "exports": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+
+import { Player } from "./player.js";
+
+const args = process.argv.slice(2);
+
+const HELP = `
+Usage: cli-sound [options] <filepath>
+
+Options:
+  -v, --volume    Set the volume (0-1).
+  -h, --help      Show this help message and exit.
+`.trim();
+
+if (args[0] === "-h" || args[0] === "--help") {
+  console.log(HELP);
+  process.exit(0);
+}
+
+let volume = 1;
+let filePath: string;
+
+if (args[0] === "-v" || args[0] === "--volume") {
+  volume = Number(args[1]);
+  filePath = args[2];
+} else {
+  filePath = args[0];
+}
+
+const absoluteFilePath = path.resolve(process.cwd(), filePath);
+
+async function main() {
+  try {
+    const player = new Player({ volume });
+
+    try {
+      console.log(`Playing ${filePath}`);
+      await player.play(absoluteFilePath);
+    } catch (error) {
+      console.error("There was an error playing the file:");
+      console.error(error);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error("There was an error creating the player:");
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This pull request adds a new binary to the package called `cli-sound`. It allows users to play sound files directly from the terminal.