### PR TITLE
Remove useless console.log statement in cli.ts

### DIFF
--- a/.changeset/four-fireants-sniff.md
+++ b/.changeset/four-fireants-sniff.md
@@ -1,0 +1,5 @@
+---
+"cli-sound": patch
+---
+
+Fix useless log in binary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,6 @@ async function main() {
     const player = new Player({ volume });
 
     try {
-      console.log(`Playing ${filePath}`);
       await player.play(absoluteFilePath);
     } catch (error) {
       console.error("There was an error playing the file:");


### PR DESCRIPTION
This pull request removes a console.log statement in cli.ts that was not providing any useful information. It cleans up the output of the binary.